### PR TITLE
fix: 운영환경 API baseURL을 /api/v1로 수정하여 nginx 프록시 경로 매칭

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,7 +1,7 @@
 # 운영환경 API 서버 URL 설정
 # nginx: /api/* → http://springboot:8080/* (즉, /api/ 제거 후 프록시)
 # 프론트: /api/v1/dashboard → nginx: /v1/dashboard → 백엔드: /v1/dashboard
-VITE_API_URL=/api
+VITE_API_URL=/api/v1
 
 # 운영환경 구분
 VITE_ENV=production


### PR DESCRIPTION
## PR 종류
- [ ] 기능 개선
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [X] 기타

##변경 사항
운영환경 API baseURL을 /api/v1로 수정

##관련 이슈- 관련된 이슈 번호를 적어주세요
Closes #68
Closes #67
